### PR TITLE
Support batch requesting for rates

### DIFF
--- a/dist/blockchains/eos/index.d.ts
+++ b/dist/blockchains/eos/index.d.ts
@@ -7,7 +7,7 @@ export declare class EOS implements Blockchain {
     refresh(): Promise<void>;
     getAnchorToken(): Token;
     getPaths(from: Token, to: Token): Promise<Token[][]>;
-    getRates(paths: Token[][], amount: string): Promise<string[]>;
+    getRates(paths: Token[][], amounts: string[]): Promise<string[][]>;
     getConverterVersion(converter: Converter): Promise<string>;
     getConversionEvents(token: Token, fromBlock: number, toBlock: number): Promise<ConversionEvent[]>;
     getConversionEventsByTimestamp(token: Token, fromTimestamp: number, toTimestamp: number): Promise<ConversionEvent[]>;

--- a/dist/blockchains/eos/index.js
+++ b/dist/blockchains/eos/index.js
@@ -1,4 +1,23 @@
 "use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -38,14 +57,8 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
-var __importStar = (this && this.__importStar) || function (mod) {
-    if (mod && mod.__esModule) return mod;
-    var result = {};
-    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
-    result["default"] = mod;
-    return result;
-};
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.EOS = void 0;
 var eosjs_1 = require("eosjs");
 var node_fetch_1 = __importDefault(require("node-fetch"));
 var helpers = __importStar(require("../../helpers"));
@@ -104,14 +117,11 @@ var EOS = /** @class */ (function () {
             });
         });
     };
-    EOS.prototype.getRates = function (paths, amount) {
+    EOS.prototype.getRates = function (paths, amounts) {
         return __awaiter(this, void 0, void 0, function () {
             var _this = this;
             return __generator(this, function (_a) {
-                switch (_a.label) {
-                    case 0: return [4 /*yield*/, Promise.all(paths.map(function (path) { return _this.getRateByPath(path, amount); }))];
-                    case 1: return [2 /*return*/, _a.sent()];
-                }
+                return [2 /*return*/, Promise.all(amounts.map(function (amount) { return Promise.all(paths.map(function (path) { return _this.getRateByPath(path, amount); })); }))];
             });
         });
     };

--- a/dist/blockchains/eos/index.js
+++ b/dist/blockchains/eos/index.js
@@ -119,21 +119,10 @@ var EOS = /** @class */ (function () {
     };
     EOS.prototype.getRates = function (paths, amounts) {
         return __awaiter(this, void 0, void 0, function () {
-            var ratesPromises;
             var _this = this;
             return __generator(this, function (_a) {
                 switch (_a.label) {
-                    case 0:
-                        ratesPromises = Array(amounts.length).fill(['']).map(function (_, i) { return __awaiter(_this, void 0, void 0, function () {
-                            var _this = this;
-                            return __generator(this, function (_a) {
-                                switch (_a.label) {
-                                    case 0: return [4 /*yield*/, Promise.all(paths.map(function (p) { return _this.getRateByPath(p, amounts[i]); }))];
-                                    case 1: return [2 /*return*/, _a.sent()];
-                                }
-                            });
-                        }); });
-                        return [4 /*yield*/, Promise.all(ratesPromises)];
+                    case 0: return [4 /*yield*/, Promise.all(amounts.map(function (a, i) { return Promise.all(paths.map(function (p) { return _this.getRateByPath(p, a); })); }))];
                     case 1: return [2 /*return*/, _a.sent()];
                 }
             });

--- a/dist/blockchains/eos/index.js
+++ b/dist/blockchains/eos/index.js
@@ -119,9 +119,23 @@ var EOS = /** @class */ (function () {
     };
     EOS.prototype.getRates = function (paths, amounts) {
         return __awaiter(this, void 0, void 0, function () {
+            var ratesPromises;
             var _this = this;
             return __generator(this, function (_a) {
-                return [2 /*return*/, Promise.all(amounts.map(function (amount) { return Promise.all(paths.map(function (path) { return _this.getRateByPath(path, amount); })); }))];
+                switch (_a.label) {
+                    case 0:
+                        ratesPromises = Array(amounts.length).fill(['']).map(function (_, i) { return __awaiter(_this, void 0, void 0, function () {
+                            var _this = this;
+                            return __generator(this, function (_a) {
+                                switch (_a.label) {
+                                    case 0: return [4 /*yield*/, Promise.all(paths.map(function (p) { return _this.getRateByPath(p, amounts[i]); }))];
+                                    case 1: return [2 /*return*/, _a.sent()];
+                                }
+                            });
+                        }); });
+                        return [4 /*yield*/, Promise.all(ratesPromises)];
+                    case 1: return [2 /*return*/, _a.sent()];
+                }
             });
         });
     };

--- a/dist/blockchains/ethereum/abis.js
+++ b/dist/blockchains/ethereum/abis.js
@@ -1,5 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.MulticallContract = exports.ERC20Token = exports.BancorConverterRegistry = exports.BancorNetwork = exports.ContractRegistry = void 0;
 exports.ContractRegistry = [
     { "constant": true, "inputs": [{ "name": "_contractName", "type": "bytes32" }], "name": "addressOf", "outputs": [{ "name": "", "type": "address" }], "payable": false, "stateMutability": "view", "type": "function" }
 ];

--- a/dist/blockchains/ethereum/conversion_events.js
+++ b/dist/blockchains/ethereum/conversion_events.js
@@ -46,6 +46,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.get = void 0;
 var web3_1 = __importDefault(require("web3"));
 var abis_1 = require("./abis");
 var helpers_1 = require("../../helpers");

--- a/dist/blockchains/ethereum/converter_version.js
+++ b/dist/blockchains/ethereum/converter_version.js
@@ -36,6 +36,7 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
     }
 };
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.get = void 0;
 function rpc(func) {
     return __awaiter(this, void 0, void 0, function () {
         var error_1;

--- a/dist/blockchains/ethereum/index.d.ts
+++ b/dist/blockchains/ethereum/index.d.ts
@@ -15,6 +15,11 @@ export declare class Ethereum implements Blockchain {
     refresh(): Promise<void>;
     getAnchorToken(): Token;
     getPaths(sourceToken: Token, targetToken: Token): Promise<Token[][]>;
+    /**
+     * @param tokenPaths paths to get rates for
+     * @param tokenAmounts input amounts to get rates for
+     * @returns The rates for each path in order, grouped by input amounts in order
+     */
     getRates(tokenPaths: Token[][], tokenAmounts: string[]): Promise<string[][]>;
     getConverterVersion(converter: Converter): Promise<string>;
     getConversionEvents(token: Token, fromBlock: number, toBlock: number): Promise<ConversionEvent[]>;

--- a/dist/blockchains/ethereum/index.d.ts
+++ b/dist/blockchains/ethereum/index.d.ts
@@ -15,7 +15,7 @@ export declare class Ethereum implements Blockchain {
     refresh(): Promise<void>;
     getAnchorToken(): Token;
     getPaths(sourceToken: Token, targetToken: Token): Promise<Token[][]>;
-    getRates(tokenPaths: Token[][], tokenAmount: string): Promise<string[]>;
+    getRates(tokenPaths: Token[][], tokenAmounts: string[]): Promise<string[][]>;
     getConverterVersion(converter: Converter): Promise<string>;
     getConversionEvents(token: Token, fromBlock: number, toBlock: number): Promise<ConversionEvent[]>;
     getConversionEventsByTimestamp(token: Token, fromTimestamp: number, toTimestamp: number): Promise<ConversionEvent[]>;
@@ -26,5 +26,5 @@ export declare class Ethereum implements Blockchain {
 export declare const getWeb3: (nodeEndpoint: any) => any;
 export declare const getContractAddresses: (ethereum: any) => any;
 export declare const getDecimals: (ethereum: any, token: any) => Promise<any>;
-export declare const getRates: (ethereum: any, paths: any, amount: any) => Promise<any>;
+export declare const getRates: (ethereum: any, paths: any, amounts: any) => Promise<string[][]>;
 export declare const getTokens: (ethereum: any) => Promise<any>;

--- a/dist/blockchains/ethereum/index.js
+++ b/dist/blockchains/ethereum/index.js
@@ -10,6 +10,25 @@ var __assign = (this && this.__assign) || function () {
     };
     return __assign.apply(this, arguments);
 };
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -56,14 +75,8 @@ var __spreadArrays = (this && this.__spreadArrays) || function () {
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
-var __importStar = (this && this.__importStar) || function (mod) {
-    if (mod && mod.__esModule) return mod;
-    var result = {};
-    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
-    result["default"] = mod;
-    return result;
-};
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.getTokens = exports.getRates = exports.getDecimals = exports.getContractAddresses = exports.getWeb3 = exports.Ethereum = void 0;
 var web3_1 = __importDefault(require("web3"));
 var abis = __importStar(require("./abis"));
 var helpers = __importStar(require("../../helpers"));
@@ -175,9 +188,9 @@ var Ethereum = /** @class */ (function () {
             });
         });
     };
-    Ethereum.prototype.getRates = function (tokenPaths, tokenAmount) {
+    Ethereum.prototype.getRates = function (tokenPaths, tokenAmounts) {
         return __awaiter(this, void 0, void 0, function () {
-            var addressPaths, sourceDecimals, targetDecimals, tokenRates;
+            var addressPaths, sourceDecimals, targetDecimals, tokenRatesByAmount;
             return __generator(this, function (_a) {
                 switch (_a.label) {
                     case 0:
@@ -188,10 +201,10 @@ var Ethereum = /** @class */ (function () {
                         return [4 /*yield*/, exports.getDecimals(this, addressPaths[0].slice(-1)[0])];
                     case 2:
                         targetDecimals = _a.sent();
-                        return [4 /*yield*/, getRatesSafe(this, addressPaths, helpers.toWei(tokenAmount, sourceDecimals))];
+                        return [4 /*yield*/, getRatesSafe(this, addressPaths, tokenAmounts.map(function (amt) { return helpers.toWei(amt, sourceDecimals); }))];
                     case 3:
-                        tokenRates = _a.sent();
-                        return [2 /*return*/, tokenRates.map(function (tokenRate) { return helpers.fromWei(tokenRate, targetDecimals); })];
+                        tokenRatesByAmount = _a.sent();
+                        return [2 /*return*/, tokenRatesByAmount.map(function (tokenRates) { return tokenRates.map(function (tokenRate) { return helpers.fromWei(tokenRate, targetDecimals); }); })];
                 }
             });
         });
@@ -300,43 +313,48 @@ exports.getDecimals = function (ethereum, token) {
         });
     });
 };
-function getRatesSafe(ethereum, paths, amount) {
+function getRatesSafe(ethereum, paths, amounts) {
     return __awaiter(this, void 0, void 0, function () {
-        var error_1, mid, arr1, arr2;
+        var error_1, mid, arr1_1, arr2_1;
         return __generator(this, function (_a) {
             switch (_a.label) {
                 case 0:
                     _a.trys.push([0, 2, , 6]);
-                    return [4 /*yield*/, exports.getRates(ethereum, paths, amount)];
+                    return [4 /*yield*/, exports.getRates(ethereum, paths, amounts)];
                 case 1: return [2 /*return*/, _a.sent()];
                 case 2:
                     error_1 = _a.sent();
                     if (!(paths.length > 1)) return [3 /*break*/, 5];
                     mid = paths.length >> 1;
-                    return [4 /*yield*/, getRatesSafe(ethereum, paths.slice(0, mid), amount)];
+                    return [4 /*yield*/, getRatesSafe(ethereum, paths.slice(0, mid), amounts)];
                 case 3:
-                    arr1 = _a.sent();
-                    return [4 /*yield*/, getRatesSafe(ethereum, paths.slice(mid, paths.length), amount)];
+                    arr1_1 = _a.sent();
+                    return [4 /*yield*/, getRatesSafe(ethereum, paths.slice(mid, paths.length), amounts)];
                 case 4:
-                    arr2 = _a.sent();
-                    return [2 /*return*/, __spreadArrays(arr1, arr2)];
-                case 5: return [2 /*return*/, ['0']];
+                    arr2_1 = _a.sent();
+                    return [2 /*return*/, Array(amounts.length).fill([]).map(function (_, i) { return __spreadArrays(arr1_1[i], arr2_1[i]); })];
+                case 5: return [2 /*return*/, Array(amounts.length).fill(Array(paths.length).fill('0'))];
                 case 6: return [2 /*return*/];
             }
         });
     });
 }
-exports.getRates = function (ethereum, paths, amount) {
+exports.getRates = function (ethereum, paths, amounts) {
     return __awaiter(this, void 0, void 0, function () {
         var calls, _a, blockNumber, returnData;
         return __generator(this, function (_b) {
             switch (_b.label) {
                 case 0:
-                    calls = paths.map(function (path) { return [ethereum.bancorNetwork._address, ethereum.bancorNetwork.methods.getReturnByPath(path, amount).encodeABI()]; });
+                    calls = amounts.map(function (amount) {
+                        paths.map(function (path) { return [ethereum.bancorNetwork._address, ethereum.bancorNetwork.methods.getReturnByPath(path, amount).encodeABI()]; });
+                    }).reduce(function (array, val) { return array.concat(val); }, []);
                     return [4 /*yield*/, ethereum.multicallContract.methods.aggregate(calls, false).call()];
                 case 1:
                     _a = _b.sent(), blockNumber = _a[0], returnData = _a[1];
-                    return [2 /*return*/, returnData.map(function (item) { return item.success ? web3_1.default.utils.toBN(item.data.substr(0, 66)).toString() : '0'; })];
+                    return [2 /*return*/, Array(amounts.length).fill('0').map(function (_, i) {
+                            var _returnData = returnData.slice(i * paths.length, i * paths.length + paths.length);
+                            return _returnData.map(function (item) { return item.success ? web3_1.default.utils.toBN(item.data.substr(0, 66)).toString() : '0'; });
+                        })];
             }
         });
     });

--- a/dist/blockchains/ethereum/index.js
+++ b/dist/blockchains/ethereum/index.js
@@ -188,9 +188,14 @@ var Ethereum = /** @class */ (function () {
             });
         });
     };
+    /**
+     * @param tokenPaths paths to get rates for
+     * @param tokenAmounts input amounts to get rates for
+     * @returns The rates for each path in order, grouped by input amounts in order
+     */
     Ethereum.prototype.getRates = function (tokenPaths, tokenAmounts) {
         return __awaiter(this, void 0, void 0, function () {
-            var addressPaths, sourceDecimals, targetDecimals, tokenRatesByAmount;
+            var addressPaths, sourceDecimals, targetDecimals, tokenRatesPerAmount;
             return __generator(this, function (_a) {
                 switch (_a.label) {
                     case 0:
@@ -201,10 +206,10 @@ var Ethereum = /** @class */ (function () {
                         return [4 /*yield*/, exports.getDecimals(this, addressPaths[0].slice(-1)[0])];
                     case 2:
                         targetDecimals = _a.sent();
-                        return [4 /*yield*/, getRatesSafe(this, addressPaths, tokenAmounts.map(function (amt) { return helpers.toWei(amt, sourceDecimals); }))];
+                        return [4 /*yield*/, getRatesSafe(this, addressPaths, tokenAmounts.map(function (tokenAmount) { return helpers.toWei(tokenAmount, sourceDecimals); }))];
                     case 3:
-                        tokenRatesByAmount = _a.sent();
-                        return [2 /*return*/, tokenRatesByAmount.map(function (tokenRates) { return tokenRates.map(function (tokenRate) { return helpers.fromWei(tokenRate, targetDecimals); }); })];
+                        tokenRatesPerAmount = _a.sent();
+                        return [2 /*return*/, tokenRatesPerAmount.map(function (tokenRates) { return tokenRates.map(function (tokenRate) { return helpers.fromWei(tokenRate, targetDecimals); }); })];
                 }
             });
         });

--- a/dist/blockchains/ethereum/timestamp_to_block_number.js
+++ b/dist/blockchains/ethereum/timestamp_to_block_number.js
@@ -36,6 +36,7 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
     }
 };
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.timestampToBlockNumber = void 0;
 function timestampToBlockNumber(web3, timestamp) {
     return __awaiter(this, void 0, void 0, function () {
         var lo, hi, block;

--- a/dist/core.d.ts
+++ b/dist/core.d.ts
@@ -6,6 +6,12 @@ export declare class Core {
     create(settings: Settings): Promise<void>;
     destroy(): Promise<void>;
     refresh(): Promise<void>;
+    /**
+     * @param sourceToken input token
+     * @param targetToken output token
+     * @param amounts input amounts in token decimals
+     * @returns The best rate and corresponding path for each input amount
+     */
     getPathAndRates(sourceToken: Token, targetToken: Token, amounts?: string[]): Promise<Array<{
         path: Token[];
         rate: string;

--- a/dist/core.d.ts
+++ b/dist/core.d.ts
@@ -6,10 +6,10 @@ export declare class Core {
     create(settings: Settings): Promise<void>;
     destroy(): Promise<void>;
     refresh(): Promise<void>;
-    getPathAndRate(sourceToken: Token, targetToken: Token, amount?: string): Promise<{
+    getPathAndRates(sourceToken: Token, targetToken: Token, amounts?: string[]): Promise<Array<{
         path: Token[];
         rate: string;
-    }>;
+    }>>;
     getRateByPath(path: Token[], amount?: string): Promise<string>;
     private refreshIfNeeded;
     private getPaths;

--- a/dist/core.js
+++ b/dist/core.js
@@ -150,10 +150,16 @@ var Core = /** @class */ (function () {
             });
         });
     };
+    /**
+     * @param sourceToken input token
+     * @param targetToken output token
+     * @param amounts input amounts in token decimals
+     * @returns The best rate and corresponding path for each input amount
+     */
     Core.prototype.getPathAndRates = function (sourceToken, targetToken, amounts) {
         if (amounts === void 0) { amounts = ['1']; }
         return __awaiter(this, void 0, void 0, function () {
-            var sourceBlockchain, targetBlockchain, paths_1, ratesByAmount, sourcePaths, sourceRatesByAmount, sourceIndicesByAmount, bestSourceRates, targetPaths, targetRatesByAmount, targetIndicesByAmount;
+            var sourceBlockchain, targetBlockchain, paths_1, rates_1, bestIndices, sourcePaths, sourceRatesByAmount, sourceIndicesByAmount, bestSourceRates, targetPaths, targetRatesByAmount, targetIndicesByAmount;
             return __generator(this, function (_a) {
                 switch (_a.label) {
                     case 0: return [4 /*yield*/, this.refreshIfNeeded()];
@@ -167,14 +173,9 @@ var Core = /** @class */ (function () {
                         paths_1 = _a.sent();
                         return [4 /*yield*/, this.getRates(sourceToken.blockchainType, paths_1, amounts)];
                     case 3:
-                        ratesByAmount = _a.sent();
-                        return [2 /*return*/, ratesByAmount.map(function (rates) {
-                                var index = Core.getBest(paths_1, rates);
-                                return {
-                                    path: paths_1[index],
-                                    rate: rates[index]
-                                };
-                            })];
+                        rates_1 = _a.sent();
+                        bestIndices = rates_1.map(function (r) { return Core.getBest(paths_1, r); });
+                        return [2 /*return*/, bestIndices.map(function (best, i) { return ({ path: paths_1[best], rate: rates_1[i][best] }); })];
                     case 4: return [4 /*yield*/, this.getPaths(sourceToken.blockchainType, sourceToken, sourceBlockchain.getAnchorToken())];
                     case 5:
                         sourcePaths = _a.sent();

--- a/dist/core.js
+++ b/dist/core.js
@@ -1,4 +1,23 @@
 "use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -42,14 +61,8 @@ var __spreadArrays = (this && this.__spreadArrays) || function () {
             r[k] = a[j];
     return r;
 };
-var __importStar = (this && this.__importStar) || function (mod) {
-    if (mod && mod.__esModule) return mod;
-    var result = {};
-    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
-    result["default"] = mod;
-    return result;
-};
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.Core = void 0;
 var helpers = __importStar(require("./helpers"));
 var ethereum_1 = require("./blockchains/ethereum");
 var eos_1 = require("./blockchains/eos");
@@ -137,10 +150,10 @@ var Core = /** @class */ (function () {
             });
         });
     };
-    Core.prototype.getPathAndRate = function (sourceToken, targetToken, amount) {
-        if (amount === void 0) { amount = '1'; }
+    Core.prototype.getPathAndRates = function (sourceToken, targetToken, amounts) {
+        if (amounts === void 0) { amounts = ['1']; }
         return __awaiter(this, void 0, void 0, function () {
-            var sourceBlockchain, targetBlockchain, paths, rates, index, sourcePaths, sourceRates, sourceIndex, targetPaths, targetRates, targetIndex;
+            var sourceBlockchain, targetBlockchain, paths_1, ratesByAmount, sourcePaths, sourceRatesByAmount, sourceIndicesByAmount, bestSourceRates, targetPaths, targetRatesByAmount, targetIndicesByAmount;
             return __generator(this, function (_a) {
                 switch (_a.label) {
                     case 0: return [4 /*yield*/, this.refreshIfNeeded()];
@@ -151,33 +164,36 @@ var Core = /** @class */ (function () {
                         if (!(sourceBlockchain == targetBlockchain)) return [3 /*break*/, 4];
                         return [4 /*yield*/, this.getPaths(sourceToken.blockchainType, sourceToken, targetToken)];
                     case 2:
-                        paths = _a.sent();
-                        return [4 /*yield*/, this.getRates(sourceToken.blockchainType, paths, amount)];
+                        paths_1 = _a.sent();
+                        return [4 /*yield*/, this.getRates(sourceToken.blockchainType, paths_1, amounts)];
                     case 3:
-                        rates = _a.sent();
-                        index = Core.getBest(paths, rates);
-                        return [2 /*return*/, {
-                                path: paths[index],
-                                rate: rates[index]
-                            }];
+                        ratesByAmount = _a.sent();
+                        return [2 /*return*/, ratesByAmount.map(function (rates) {
+                                var index = Core.getBest(paths_1, rates);
+                                return {
+                                    path: paths_1[index],
+                                    rate: rates[index]
+                                };
+                            })];
                     case 4: return [4 /*yield*/, this.getPaths(sourceToken.blockchainType, sourceToken, sourceBlockchain.getAnchorToken())];
                     case 5:
                         sourcePaths = _a.sent();
-                        return [4 /*yield*/, this.getRates(sourceToken.blockchainType, sourcePaths, amount)];
+                        return [4 /*yield*/, this.getRates(sourceToken.blockchainType, sourcePaths, amounts)];
                     case 6:
-                        sourceRates = _a.sent();
-                        sourceIndex = Core.getBest(sourcePaths, sourceRates);
+                        sourceRatesByAmount = _a.sent();
+                        sourceIndicesByAmount = sourceRatesByAmount.map(function (rates) { return Core.getBest(sourcePaths, rates); });
+                        bestSourceRates = sourceIndicesByAmount.map(function (amountIndex, rateIndex) { return sourceRatesByAmount[amountIndex][rateIndex]; });
                         return [4 /*yield*/, this.getPaths(targetToken.blockchainType, targetBlockchain.getAnchorToken(), targetToken)];
                     case 7:
                         targetPaths = _a.sent();
-                        return [4 /*yield*/, this.getRates(targetToken.blockchainType, targetPaths, sourceRates[sourceIndex])];
+                        return [4 /*yield*/, this.getRates(targetToken.blockchainType, targetPaths, bestSourceRates)];
                     case 8:
-                        targetRates = _a.sent();
-                        targetIndex = Core.getBest(targetPaths, targetRates);
-                        return [2 /*return*/, {
-                                path: __spreadArrays(sourcePaths[sourceIndex], targetPaths[targetIndex]),
-                                rate: targetRates[targetIndex],
-                            }];
+                        targetRatesByAmount = _a.sent();
+                        targetIndicesByAmount = targetRatesByAmount.map(function (rates) { return Core.getBest(targetPaths, rates); });
+                        return [2 /*return*/, Array(amounts.length).fill('0').map(function (_, i) { return ({
+                                path: __spreadArrays(sourcePaths[sourceIndicesByAmount[i]], targetPaths[targetIndicesByAmount[i]]),
+                                rate: targetRatesByAmount[i][targetIndicesByAmount[i]],
+                            }); })];
                 }
             });
         });
@@ -194,17 +210,17 @@ var Core = /** @class */ (function () {
                         sourceBlockchainType = path[0].blockchainType;
                         targetBlockchainType = path[path.length - 1].blockchainType;
                         if (!(sourceBlockchainType == targetBlockchainType)) return [3 /*break*/, 3];
-                        return [4 /*yield*/, this.getRates(sourceBlockchainType, [path], amount)];
-                    case 2: return [2 /*return*/, (_a.sent())[0]];
+                        return [4 /*yield*/, this.getRates(sourceBlockchainType, [path], [amount])];
+                    case 2: return [2 /*return*/, (_a.sent())[0][0]];
                     case 3:
                         index = path.findIndex(function (item) { return item.blockchainType == targetBlockchainType; });
                         sourceBlockchainPath = path.slice(0, index);
                         targetBlockchainPath = path.slice(index);
-                        return [4 /*yield*/, this.getRates(sourceBlockchainType, [sourceBlockchainPath], amount)];
+                        return [4 /*yield*/, this.getRates(sourceBlockchainType, [sourceBlockchainPath], [amount])];
                     case 4:
-                        sourceBlockchainRate = (_a.sent())[0];
-                        return [4 /*yield*/, this.getRates(targetBlockchainType, [targetBlockchainPath], sourceBlockchainRate)];
-                    case 5: return [2 /*return*/, (_a.sent())[0]];
+                        sourceBlockchainRate = (_a.sent())[0][0];
+                        return [4 /*yield*/, this.getRates(targetBlockchainType, [targetBlockchainPath], [sourceBlockchainRate])];
+                    case 5: return [2 /*return*/, (_a.sent())[0][0]];
                 }
             });
         });
@@ -238,16 +254,16 @@ var Core = /** @class */ (function () {
             });
         });
     };
-    Core.prototype.getRates = function (blockchainType, paths, amount) {
-        if (amount === void 0) { amount = '1'; }
+    Core.prototype.getRates = function (blockchainType, paths, amounts) {
+        if (amounts === void 0) { amounts = ['1']; }
         return __awaiter(this, void 0, void 0, function () {
             return __generator(this, function (_a) {
                 switch (_a.label) {
                     case 0:
                         // special case for single path and source token == target token
                         if (paths.length == 1 && helpers.isTokenEqual(paths[0][0], paths[0][paths[0].length - 1]))
-                            return [2 /*return*/, [amount]];
-                        return [4 /*yield*/, this.blockchains[blockchainType].getRates(paths, amount)];
+                            return [2 /*return*/, amounts.map(function (amt) { return [amt]; })];
+                        return [4 /*yield*/, this.blockchains[blockchainType].getRates(paths, amounts)];
                     case 1: return [2 /*return*/, _a.sent()];
                 }
             });

--- a/dist/helpers.js
+++ b/dist/helpers.js
@@ -10,6 +10,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.getReturn = exports.getFinalAmount = exports.liquidateReserveAmount = exports.fundSupplyAmount = exports.fundCost = exports.crossReserveTargetAmount = exports.saleTargetAmount = exports.purchaseTargetAmount = exports.isTokenEqual = exports.toDecimalPlaces = exports.fromWei = exports.toWei = void 0;
 var decimal_js_1 = __importDefault(require("decimal.js"));
 var ZERO = new decimal_js_1.default(0);
 var ONE = new decimal_js_1.default(1);

--- a/dist/history.js
+++ b/dist/history.js
@@ -49,6 +49,7 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
     }
 };
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.History = void 0;
 var sdk_module_1 = require("./sdk_module");
 /**
  * The History module allows querying historical data in the bancor network

--- a/dist/index.js
+++ b/dist/index.js
@@ -36,6 +36,7 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
     }
 };
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.SDK = void 0;
 var core_1 = require("./core");
 var history_1 = require("./history");
 var pricing_1 = require("./pricing");

--- a/dist/pricing.d.ts
+++ b/dist/pricing.d.ts
@@ -18,6 +18,19 @@ export declare class Pricing extends SDKModule {
         rate: string;
     }>;
     /**
+    * returns the best conversion paths and rates for a given pair of tokens and input amounts in the bancor network
+    *
+    * @param sourceToken    source token
+    * @param targetToken    target token
+    * @param amounts         input amounts
+    *
+    * @returns  the best paths and rates between the source token and the target token for each input amount
+    */
+    getPathAndRates(sourceToken: Token, targetToken: Token, amounts?: string[]): Promise<{
+        path: Token[];
+        rate: string;
+    }>;
+    /**
     * returns the rate for a given conversion path in the bancor network
     *
     * @param path    conversion path

--- a/dist/pricing.js
+++ b/dist/pricing.js
@@ -49,6 +49,7 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
     }
 };
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.Pricing = void 0;
 var sdk_module_1 = require("./sdk_module");
 /**
  * The Pricing module provides access to pricing and rates logic for tokens in the bancor network
@@ -72,7 +73,27 @@ var Pricing = /** @class */ (function (_super) {
         return __awaiter(this, void 0, void 0, function () {
             return __generator(this, function (_a) {
                 switch (_a.label) {
-                    case 0: return [4 /*yield*/, this.core.getPathAndRate(sourceToken, targetToken, amount)];
+                    case 0: return [4 /*yield*/, this.core.getPathAndRates(sourceToken, targetToken, [amount])];
+                    case 1: return [2 /*return*/, (_a.sent())[0]];
+                }
+            });
+        });
+    };
+    /**
+    * returns the best conversion paths and rates for a given pair of tokens and input amounts in the bancor network
+    *
+    * @param sourceToken    source token
+    * @param targetToken    target token
+    * @param amounts         input amounts
+    *
+    * @returns  the best paths and rates between the source token and the target token for each input amount
+    */
+    Pricing.prototype.getPathAndRates = function (sourceToken, targetToken, amounts) {
+        if (amounts === void 0) { amounts = ['1']; }
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this.core.getPathAndRates(sourceToken, targetToken, amounts)];
                     case 1: return [2 /*return*/, _a.sent()];
                 }
             });

--- a/dist/sdk_module.js
+++ b/dist/sdk_module.js
@@ -1,5 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.SDKModule = void 0;
 var SDKModule = /** @class */ (function () {
     function SDKModule(core) {
         this.core = null;

--- a/dist/types.d.ts
+++ b/dist/types.d.ts
@@ -54,7 +54,7 @@ export interface ConversionEvent {
 export interface Blockchain {
     getAnchorToken(): Token;
     getPaths(sourceToken: Token, targetToken: Token): Promise<Token[][]>;
-    getRates(tokenPaths: Token[][], tokenAmount: string): Promise<string[]>;
+    getRates(tokenPaths: Token[][], tokenAmounts: string[]): Promise<string[][]>;
     getConverterVersion(converter: Converter): Promise<string>;
     getConversionEvents(token: Token, fromBlock: number, toBlock: number): Promise<ConversionEvent[]>;
     getConversionEventsByTimestamp(token: Token, fromTimestamp: number, toTimestamp: number): Promise<ConversionEvent[]>;

--- a/dist/types.js
+++ b/dist/types.js
@@ -1,5 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.BlockchainType = void 0;
 /**
 * blockchain types supported by the SDK
 */

--- a/dist/utils.js
+++ b/dist/utils.js
@@ -49,6 +49,7 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
     }
 };
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.Utils = void 0;
 var sdk_module_1 = require("./sdk_module");
 /**
  * The Utils module provides various utility and helper functions

--- a/src/blockchains/eos/index.ts
+++ b/src/blockchains/eos/index.ts
@@ -37,7 +37,12 @@ export class EOS implements Blockchain {
     }
 
     async getRates(paths: Token[][], amounts: string[]): Promise<string[][]> {
-        return Promise.all(amounts.map(amount => Promise.all(paths.map(path => this.getRateByPath(path, amount)))));
+        // ratesPromises is an array of promises, grouped by amount
+        // e.g. [[rateForPath1, rateForPath2, rateForPath3, ...], [rateForPath1, rateForPath2, rateForPath3, ...], ...]
+        const ratesPromises = Array(amounts.length).fill(['']).map(async (_, i) => {
+            return await Promise.all(paths.map(p => this.getRateByPath(p, amounts[i])));
+        });
+        return await Promise.all(ratesPromises);
     }
 
     async getConverterVersion(converter: Converter): Promise<string> {

--- a/src/blockchains/eos/index.ts
+++ b/src/blockchains/eos/index.ts
@@ -36,8 +36,8 @@ export class EOS implements Blockchain {
         return [EOS.getShortestPath(sourcePath, targetPath)];
     }
 
-    async getRates(paths: Token[][], amount: string): Promise<string[]> {
-        return await Promise.all(paths.map(path => this.getRateByPath(path, amount)));
+    async getRates(paths: Token[][], amounts: string[]): Promise<string[][]> {
+        return Promise.all(amounts.map(amount => Promise.all(paths.map(path => this.getRateByPath(path, amount)))));
     }
 
     async getConverterVersion(converter: Converter): Promise<string> {

--- a/src/blockchains/eos/index.ts
+++ b/src/blockchains/eos/index.ts
@@ -37,12 +37,7 @@ export class EOS implements Blockchain {
     }
 
     async getRates(paths: Token[][], amounts: string[]): Promise<string[][]> {
-        // ratesPromises is an array of promises, grouped by amount
-        // e.g. [[rateForPath1, rateForPath2, rateForPath3, ...], [rateForPath1, rateForPath2, rateForPath3, ...], ...]
-        const ratesPromises = Array(amounts.length).fill(['']).map(async (_, i) => {
-            return await Promise.all(paths.map(p => this.getRateByPath(p, amounts[i])));
-        });
-        return await Promise.all(ratesPromises);
+        return await Promise.all(amounts.map((a, i) => Promise.all(paths.map(p => this.getRateByPath(p, a)))));
     }
 
     async getConverterVersion(converter: Converter): Promise<string> {

--- a/src/blockchains/ethereum/index.ts
+++ b/src/blockchains/ethereum/index.ts
@@ -89,12 +89,12 @@ export class Ethereum implements Blockchain {
         return addressPaths.map(addressPath => addressPath.map(address => ({blockchainType: BlockchainType.Ethereum, blockchainId: address})));
     }
 
-    async getRates(tokenPaths: Token[][], tokenAmount: string): Promise<string[]> {
+    async getRates(tokenPaths: Token[][], tokenAmounts: string[]): Promise<string[][]> {
         const addressPaths = tokenPaths.map(tokenPath => tokenPath.map(token => Web3.utils.toChecksumAddress(token.blockchainId)));
         const sourceDecimals = await getDecimals(this, addressPaths[0][0]);
         const targetDecimals = await getDecimals(this, addressPaths[0].slice(-1)[0]);
-        const tokenRates = await getRatesSafe(this, addressPaths, helpers.toWei(tokenAmount, sourceDecimals));
-        return tokenRates.map(tokenRate => helpers.fromWei(tokenRate, targetDecimals));
+        const tokenRatesByAmount = await getRatesSafe(this, addressPaths, tokenAmounts.map(amt => helpers.toWei(amt, sourceDecimals)));
+        return tokenRatesByAmount.map(tokenRates => tokenRates.map(tokenRate => helpers.fromWei(tokenRate, targetDecimals)));
     }
 
     async getConverterVersion(converter: Converter): Promise<string> {
@@ -165,26 +165,32 @@ export const getDecimals = async function(ethereum, token) {
     return ethereum.decimals[token];
 };
 
-async function getRatesSafe(ethereum, paths, amount) {
+async function getRatesSafe(ethereum, paths, amounts) {
     try {
-        return await getRates(ethereum, paths, amount);
+        return await getRates(ethereum, paths, amounts);
     }
     catch (error) {
         if (paths.length > 1) {
             const mid = paths.length >> 1;
-            const arr1 = await getRatesSafe(ethereum, paths.slice(0, mid), amount);
-            const arr2 = await getRatesSafe(ethereum, paths.slice(mid, paths.length), amount);
-            return [...arr1, ...arr2];
+            const arr1 = await getRatesSafe(ethereum, paths.slice(0, mid), amounts);
+            const arr2 = await getRatesSafe(ethereum, paths.slice(mid, paths.length), amounts);
+            return Array(amounts.length).fill([]).map((_, i) => [...arr1[i], ...arr2[i]]);
         }
-        return ['0'];
+        return Array(amounts.length).fill(Array(paths.length).fill('0'));
     }
 }
 
-export const getRates = async function(ethereum, paths, amount) {
-    const calls = paths.map(path => [ethereum.bancorNetwork._address, ethereum.bancorNetwork.methods.getReturnByPath(path, amount).encodeABI()]);
+export const getRates = async function(ethereum, paths, amounts): Promise<string[][]> {
+    const calls = amounts.map(amount => {
+        paths.map(path => [ethereum.bancorNetwork._address, ethereum.bancorNetwork.methods.getReturnByPath(path, amount).encodeABI()]);
+    }).reduce((array, val) => array.concat(val), []);
+
     const [blockNumber, returnData] = await ethereum.multicallContract.methods.aggregate(calls, false).call();
-    return returnData.map(item => item.success ? Web3.utils.toBN(item.data.substr(0, 66)).toString() : '0');
-};
+    return Array(amounts.length).fill('0').map((_, i) => {
+        const _returnData = returnData.slice(i * paths.length, i * paths.length + paths.length)
+        return _returnData.map(item => item.success ? Web3.utils.toBN(item.data.substr(0, 66)).toString() : '0');
+    })
+}
 
 export const getTokens = async function(ethereum) {
     const convertibleTokens = await ethereum.converterRegistry.methods.getConvertibleTokens().call();

--- a/src/blockchains/ethereum/index.ts
+++ b/src/blockchains/ethereum/index.ts
@@ -89,12 +89,17 @@ export class Ethereum implements Blockchain {
         return addressPaths.map(addressPath => addressPath.map(address => ({blockchainType: BlockchainType.Ethereum, blockchainId: address})));
     }
 
+    /**
+     * @param tokenPaths paths to get rates for
+     * @param tokenAmounts input amounts to get rates for
+     * @returns The rates for each path in order, grouped by input amounts in order
+     */
     async getRates(tokenPaths: Token[][], tokenAmounts: string[]): Promise<string[][]> {
         const addressPaths = tokenPaths.map(tokenPath => tokenPath.map(token => Web3.utils.toChecksumAddress(token.blockchainId)));
         const sourceDecimals = await getDecimals(this, addressPaths[0][0]);
         const targetDecimals = await getDecimals(this, addressPaths[0].slice(-1)[0]);
-        const tokenRatesByAmount = await getRatesSafe(this, addressPaths, tokenAmounts.map(amt => helpers.toWei(amt, sourceDecimals)));
-        return tokenRatesByAmount.map(tokenRates => tokenRates.map(tokenRate => helpers.fromWei(tokenRate, targetDecimals)));
+        const tokenRatesPerAmount = await getRatesSafe(this, addressPaths, tokenAmounts.map(tokenAmount => helpers.toWei(tokenAmount, sourceDecimals)));
+        return tokenRatesPerAmount.map(tokenRates => tokenRates.map(tokenRate => helpers.fromWei(tokenRate, targetDecimals)));
     }
 
     async getConverterVersion(converter: Converter): Promise<string> {

--- a/src/core.ts
+++ b/src/core.ts
@@ -30,40 +30,43 @@ export class Core {
             await this.blockchains[blockchainType].refresh();
     }
 
-    async getPathAndRate(sourceToken: Token, targetToken: Token, amount: string = '1'): Promise<{path: Token[], rate: string}> {
+    async getPathAndRates(sourceToken: Token, targetToken: Token, amounts: string[] = ['1']): Promise<Array<{path: Token[], rate: string}>> {
         await this.refreshIfNeeded();
-
         const sourceBlockchain = this.blockchains[sourceToken.blockchainType];
         const targetBlockchain = this.blockchains[targetToken.blockchainType];
 
         // single blockchain path - get the path/rate from that blockchain
         if (sourceBlockchain == targetBlockchain) {
             const paths = await this.getPaths(sourceToken.blockchainType, sourceToken, targetToken);
-            const rates = await this.getRates(sourceToken.blockchainType, paths, amount);
-            const index = Core.getBest(paths, rates);
-            return {
-                path: paths[index],
-                rate: rates[index]
-            };
+            const ratesByAmount = await this.getRates(sourceToken.blockchainType, paths, amounts);
+            return ratesByAmount.map(rates => {
+                const index = Core.getBest(paths, rates);
+                return {
+                    path: paths[index],
+                    rate: rates[index]
+                };
+            });
         }
 
         // cross blockchain path
         // source blockchain - get the paths from the source token to the anchor token
         const sourcePaths = await this.getPaths(sourceToken.blockchainType, sourceToken, sourceBlockchain.getAnchorToken());
         // source blockchain - get the rates
-        const sourceRates = await this.getRates(sourceToken.blockchainType, sourcePaths, amount);
-        const sourceIndex = Core.getBest(sourcePaths, sourceRates);
+        const sourceRatesByAmount = await this.getRates(sourceToken.blockchainType, sourcePaths, amounts);
+        const sourceIndicesByAmount = sourceRatesByAmount.map(rates => Core.getBest(sourcePaths, rates));
+
+        const bestSourceRates = sourceIndicesByAmount.map((amountIndex, rateIndex) => sourceRatesByAmount[amountIndex][rateIndex]);
 
         // target blockchain - get the paths from the anchor to the target token
         const targetPaths = await this.getPaths(targetToken.blockchainType, targetBlockchain.getAnchorToken(), targetToken);
         // target blockchain - get the rates
-        const targetRates = await this.getRates(targetToken.blockchainType, targetPaths, sourceRates[sourceIndex]);
-        const targetIndex = Core.getBest(targetPaths, targetRates);
+        const targetRatesByAmount = await this.getRates(targetToken.blockchainType, targetPaths, bestSourceRates);
+        const targetIndicesByAmount = targetRatesByAmount.map(rates => Core.getBest(targetPaths, rates));
 
-        return {
-            path: [...sourcePaths[sourceIndex], ...targetPaths[targetIndex]],
-            rate: targetRates[targetIndex],
-        };
+        return Array(amounts.length).fill('0').map((_, i) => ({
+            path: [...sourcePaths[sourceIndicesByAmount[i]], ...targetPaths[targetIndicesByAmount[i]]],
+            rate: targetRatesByAmount[i][targetIndicesByAmount[i]],
+        }));
     }
 
     async getRateByPath(path: Token[], amount: string = '1'): Promise<string> {
@@ -74,7 +77,7 @@ export class Core {
 
         // single blockchain path - get the rate from that blockchain
         if (sourceBlockchainType == targetBlockchainType)
-            return (await this.getRates(sourceBlockchainType, [path], amount))[0];
+            return (await this.getRates(sourceBlockchainType, [path], [amount]))[0][0];
 
         // cross blockchain path - split the path in two
         const index = path.findIndex(item => item.blockchainType == targetBlockchainType);
@@ -82,8 +85,8 @@ export class Core {
         const targetBlockchainPath = path.slice(index);
 
         // get the rate from the source blockchain and pass it as the input for the target blockchain
-        const sourceBlockchainRate = (await this.getRates(sourceBlockchainType, [sourceBlockchainPath], amount))[0];
-        return (await this.getRates(targetBlockchainType, [targetBlockchainPath], sourceBlockchainRate))[0];
+        const sourceBlockchainRate = (await this.getRates(sourceBlockchainType, [sourceBlockchainPath], [amount]))[0][0];
+        return (await this.getRates(targetBlockchainType, [targetBlockchainPath], [sourceBlockchainRate]))[0][0];
     }
 
     private async refreshIfNeeded(): Promise<void> {
@@ -99,12 +102,12 @@ export class Core {
         return await this.blockchains[blockchainType].getPaths(sourceToken, targetToken);
     }
 
-    private async getRates(blockchainType: BlockchainType, paths: Token[][], amount: string = '1'): Promise<string[]> {
+    private async getRates(blockchainType: BlockchainType, paths: Token[][], amounts: string[] = ['1']): Promise<string[][]> {
         // special case for single path and source token == target token
         if (paths.length == 1 && helpers.isTokenEqual(paths[0][0], paths[0][paths[0].length - 1]))
-            return [amount];
+            return amounts.map(amt => [amt]);
 
-        return await this.blockchains[blockchainType].getRates(paths, amount);
+        return await this.blockchains[blockchainType].getRates(paths, amounts);
     }
 
     private static getBest(paths: Token[][], rates: string[]): number {

--- a/src/pricing.ts
+++ b/src/pricing.ts
@@ -15,8 +15,21 @@ export class Pricing extends SDKModule {
     * @returns  the best path and rate between the source token and the target token
     */
     async getPathAndRate(sourceToken: Token, targetToken: Token, amount: string = '1'): Promise<{path: Token[], rate: string}> {
-        return await this.core.getPathAndRate(sourceToken, targetToken, amount);
+        return (await this.core.getPathAndRates(sourceToken, targetToken, [amount]))[0];
     }
+
+    /**
+    * returns the best conversion paths and rates for a given pair of tokens and input amounts in the bancor network
+    * 
+    * @param sourceToken    source token
+    * @param targetToken    target token
+    * @param amounts         input amounts
+    * 
+    * @returns  the best paths and rates between the source token and the target token for each input amount
+    */
+   async getPathAndRates(sourceToken: Token, targetToken: Token, amounts: string[] = ['1']): Promise<{path: Token[], rate: string}> {
+    return await this.core.getPathAndRates(sourceToken, targetToken, amounts);
+}
 
     /**
     * returns the rate for a given conversion path in the bancor network 

--- a/src/types.ts
+++ b/src/types.ts
@@ -59,7 +59,7 @@ export interface ConversionEvent {
 export interface Blockchain {
     getAnchorToken(): Token
     getPaths(sourceToken: Token, targetToken: Token): Promise<Token[][]>;
-    getRates(tokenPaths: Token[][], tokenAmount: string): Promise<string[]>;
+    getRates(tokenPaths: Token[][], tokenAmounts: string[]): Promise<string[][]>;
     getConverterVersion(converter: Converter): Promise<string>;
     getConversionEvents(token: Token, fromBlock: number, toBlock: number): Promise<ConversionEvent[]>;
     getConversionEventsByTimestamp(token: Token, fromTimestamp: number, toTimestamp: number): Promise<ConversionEvent[]>;

--- a/tests/pricing.test.ts
+++ b/tests/pricing.test.ts
@@ -91,18 +91,36 @@ describe('rates test', () => {
             .spyOn(ethereum, 'getRates')
             .mockImplementationOnce(() => Promise.reject())
             .mockImplementationOnce(() => Promise.resolve([
-                '21113',
-                '224999733',
-                '22425888633',
-                '224258633',
-                '2249733'
+                [
+                    '21113',
+                    '224999733',
+                    '22425888633',
+                    '224258633',
+                    '2249733'
+                ],
+                [ 
+                    '422260',
+                    '4499994660',
+                    '448517772660',
+                    '4485172660',
+                    '44994660'
+                ]
             ]))
             .mockImplementationOnce(() => Promise.resolve([
-                '225888633',
-                '22524999733',
-                '225249733',
-                '2258633',
-                '213'
+                [
+                    '225888633',
+                    '22524999733',
+                    '225249733',
+                    '2258633',
+                    '213'
+                ],
+                [ 
+                    '4517772660',
+                    '450499994660',
+                    '4504994660',
+                    '45172660',
+                    '4260'
+                ]
             ]));
 
         const spyGetDecimals = jest
@@ -112,27 +130,46 @@ describe('rates test', () => {
 
         await sdk.refresh();
 
-        const received = await sdk.pricing.getPathAndRate(
+        const received = await sdk.pricing.getPathAndRates(
             { blockchainType: BlockchainType.Ethereum, blockchainId: '0x2222222222222222222222222222222222222222' },
-            { blockchainType: BlockchainType.Ethereum, blockchainId: '0x3333333333333333333333333333333333333333' }
+            { blockchainType: BlockchainType.Ethereum, blockchainId: '0x3333333333333333333333333333333333333333' },
+            [ '1', '20' ]
         );
 
-        const expected = {
-            path: [
-                { blockchainType: BlockchainType.Ethereum, blockchainId: '0x2222222222222222222222222222222222222222' },
-                { blockchainType: BlockchainType.Ethereum, blockchainId: '0x2222222222222222222222222222222222222222' },
-                { blockchainType: BlockchainType.Ethereum, blockchainId: '0x5555555555555555555555555555555555555555' },
-                { blockchainType: BlockchainType.Ethereum, blockchainId: '0x2222222222222222222222222222222222222222' },
-                { blockchainType: BlockchainType.Ethereum, blockchainId: '0x4444444444444444444444444444444444444444' },
-                { blockchainType: BlockchainType.Ethereum, blockchainId: '0x9999999999999999999999999999999999999999' },
-                { blockchainType: BlockchainType.Ethereum, blockchainId: '0x9999999999999999999999999999999999999999' },
-                { blockchainType: BlockchainType.Ethereum, blockchainId: '0x9999999999999999999999999999999999999999' },
-                { blockchainType: BlockchainType.Ethereum, blockchainId: '0x7777777777777777777777777777777777777777' },
-                { blockchainType: BlockchainType.Ethereum, blockchainId: '0x3333333333333333333333333333333333333333' },
-                { blockchainType: BlockchainType.Ethereum, blockchainId: '0x3333333333333333333333333333333333333333' }
-            ],
-            rate: '0.22524999733'
-        };
+        const expected = [
+            {
+                path: [
+                    { blockchainType: BlockchainType.Ethereum, blockchainId: '0x2222222222222222222222222222222222222222' },
+                    { blockchainType: BlockchainType.Ethereum, blockchainId: '0x2222222222222222222222222222222222222222' },
+                    { blockchainType: BlockchainType.Ethereum, blockchainId: '0x5555555555555555555555555555555555555555' },
+                    { blockchainType: BlockchainType.Ethereum, blockchainId: '0x2222222222222222222222222222222222222222' },
+                    { blockchainType: BlockchainType.Ethereum, blockchainId: '0x4444444444444444444444444444444444444444' },
+                    { blockchainType: BlockchainType.Ethereum, blockchainId: '0x9999999999999999999999999999999999999999' },
+                    { blockchainType: BlockchainType.Ethereum, blockchainId: '0x9999999999999999999999999999999999999999' },
+                    { blockchainType: BlockchainType.Ethereum, blockchainId: '0x9999999999999999999999999999999999999999' },
+                    { blockchainType: BlockchainType.Ethereum, blockchainId: '0x7777777777777777777777777777777777777777' },
+                    { blockchainType: BlockchainType.Ethereum, blockchainId: '0x3333333333333333333333333333333333333333' },
+                    { blockchainType: BlockchainType.Ethereum, blockchainId: '0x3333333333333333333333333333333333333333' }
+                ],
+                rate: '0.22524999733'
+            },
+            {
+                path: [
+                    { blockchainType: BlockchainType.Ethereum, blockchainId: '0x2222222222222222222222222222222222222222' },
+                    { blockchainType: BlockchainType.Ethereum, blockchainId: '0x2222222222222222222222222222222222222222' },
+                    { blockchainType: BlockchainType.Ethereum, blockchainId: '0x5555555555555555555555555555555555555555' },
+                    { blockchainType: BlockchainType.Ethereum, blockchainId: '0x2222222222222222222222222222222222222222' },
+                    { blockchainType: BlockchainType.Ethereum, blockchainId: '0x4444444444444444444444444444444444444444' },
+                    { blockchainType: BlockchainType.Ethereum, blockchainId: '0x9999999999999999999999999999999999999999' },
+                    { blockchainType: BlockchainType.Ethereum, blockchainId: '0x9999999999999999999999999999999999999999' },
+                    { blockchainType: BlockchainType.Ethereum, blockchainId: '0x9999999999999999999999999999999999999999' },
+                    { blockchainType: BlockchainType.Ethereum, blockchainId: '0x7777777777777777777777777777777777777777' },
+                    { blockchainType: BlockchainType.Ethereum, blockchainId: '0x3333333333333333333333333333333333333333' },
+                    { blockchainType: BlockchainType.Ethereum, blockchainId: '0x3333333333333333333333333333333333333333' }
+                ],
+                rate: '4.5049999466'
+            },
+        ]
 
         expect(received).toEqual(expected);
         expect(spyGetTokens).toHaveBeenCalledTimes(1);
@@ -140,7 +177,7 @@ describe('rates test', () => {
         expect(spyGetDecimals).toHaveBeenCalledTimes(2);
     });
 
-    it('getPathAndRate from ethereum token to ethereum token using getSomePathsFunc', async () => {
+    it('getPathAndRates from ethereum token to ethereum token using getSomePathsFunc', async () => {
         const blockchain = sdk._core.blockchains[BlockchainType.Ethereum] as ethereum.Ethereum;
         const spyGetPathsFunc = jest
             .spyOn(blockchain, 'getPathsFunc')
@@ -160,12 +197,12 @@ describe('rates test', () => {
         const spyGetRates = jest
             .spyOn(ethereum, 'getRates')
             .mockImplementationOnce(() => Promise.reject())
-            .mockImplementationOnce(() => Promise.resolve([
+            .mockImplementationOnce(() => Promise.resolve([[
                 '2258633'
-            ]))
-            .mockImplementationOnce(() => Promise.resolve([
+            ]]))
+            .mockImplementationOnce(() => Promise.resolve([[
                 '2249733'
-            ]));
+            ]]));
 
         const spyGetDecimals = jest
             .spyOn(ethereum, 'getDecimals')
@@ -174,7 +211,7 @@ describe('rates test', () => {
 
         await sdk.refresh();
 
-        const received = await sdk.pricing.getPathAndRate(
+        const received = await sdk.pricing.getPathAndRates(
             { blockchainType: BlockchainType.Ethereum, blockchainId: '0x2222222222222222222222222222222222222222' },
             { blockchainType: BlockchainType.Ethereum, blockchainId: '0x3333333333333333333333333333333333333333' }
         );
@@ -192,14 +229,14 @@ describe('rates test', () => {
             rate: '0.2258633'
         };
 
-        expect(received).toEqual(expected);
+        expect(received[0]).toEqual(expected);
         expect(spyGetTokens).toHaveBeenCalledTimes(1);
         expect(spyGetRates).toHaveBeenCalledTimes(3);
         expect(spyGetDecimals).toHaveBeenCalledTimes(2);
         expect(spyGetContractAddresses).toHaveBeenCalledTimes(2);
     });
 
-    it('getPathAndRate from ethereum token to eos token', async () => {
+    it('getPathAndRates from ethereum token to eos token', async () => {
         const spyGetContractAddresses = jest
             .spyOn(ethereum, 'getContractAddresses')
             .mockImplementation(() => ({
@@ -213,7 +250,7 @@ describe('rates test', () => {
 
         const spyGetRates = jest
             .spyOn(ethereum, 'getRates')
-            .mockImplementationOnce(() => Promise.resolve(['1000000000000000000']));
+            .mockImplementationOnce(() => Promise.resolve([['1000000000000000000']]));
 
         const spyGetDecimals = jest
             .spyOn(ethereum, 'getDecimals')
@@ -230,7 +267,7 @@ describe('rates test', () => {
 
         await sdk.refresh();
 
-        const received = await sdk.pricing.getPathAndRate(
+        const received = await sdk.pricing.getPathAndRates(
             { blockchainType: BlockchainType.Ethereum, blockchainId: '0x2222222222222222222222222222222222222222' },
             { blockchainType: BlockchainType.EOS, blockchainId: 'bbbbbbbbbbbb', symbol: 'BBB' }
         );
@@ -247,14 +284,14 @@ describe('rates test', () => {
             rate: '1.3231'
         };
 
-        expect(received).toEqual(expected);
+        expect(received[0]).toEqual(expected);
         expect(spyGetTokens).toHaveBeenCalledTimes(1);
         expect(spyGetRates).toHaveBeenCalledTimes(1);
         expect(spyGetDecimals).toHaveBeenCalledTimes(2);
         expect(spyGetContractAddresses).toHaveBeenCalledTimes(3);
     });
 
-    it('getPathAndRate from eos token to ethereum token', async () => { 
+    it('getPathAndRates from eos token to ethereum token', async () => { 
         const blockchainEOS = sdk._core.blockchains[BlockchainType.EOS] as eos.EOS;
         jest.spyOn(sdk._core.blockchains[BlockchainType.EOS], 'getAnchorToken')
             .mockImplementationOnce(() => ({ blockchainType: BlockchainType.EOS, blockchainId: 'aaaaaaaaaaaa', symbol: 'AAA' }));
@@ -276,7 +313,7 @@ describe('rates test', () => {
 
         const spyGetRates = jest
             .spyOn(ethereum, 'getRates')
-            .mockImplementationOnce(() => Promise.resolve(['33333333333333333333']));
+            .mockImplementationOnce(() => Promise.resolve([['33333333333333333333']]));
 
         const spyGetDecimals = jest
             .spyOn(ethereum, 'getDecimals')
@@ -285,7 +322,7 @@ describe('rates test', () => {
 
         await sdk.refresh();
 
-        const received = await sdk.pricing.getPathAndRate(
+        const received = await sdk.pricing.getPathAndRates(
             { blockchainType: BlockchainType.EOS, blockchainId: 'bbbbbbbbbbbb', symbol: 'BBB' },
             { blockchainType: BlockchainType.Ethereum, blockchainId: '0x2222222222222222222222222222222222222222' }
         );
@@ -302,14 +339,14 @@ describe('rates test', () => {
             rate: '33.333333333333333333'
         };
 
-        expect(received).toEqual(expected);
+        expect(received[0]).toEqual(expected);
         expect(spyGetTokens).toHaveBeenCalledTimes(1);
         expect(spyGetRates).toHaveBeenCalledTimes(1);
         expect(spyGetDecimals).toHaveBeenCalledTimes(2);
         expect(spyGetContractAddresses).toHaveBeenCalledTimes(3);
     });
 
-    it('getPathAndRate from eos token to eos token', async () => {
+    it('getPathAndRates from eos token to eos token', async () => {
         const blockchainEOS = sdk._core.blockchains[BlockchainType.EOS] as eos.EOS;
         jest.spyOn(sdk._core.blockchains[BlockchainType.EOS], 'getAnchorToken')
             .mockImplementationOnce(() => ({ blockchainType: BlockchainType.EOS, blockchainId: 'aaaaaaaaaaaa', symbol: 'AAA' }));
@@ -339,7 +376,7 @@ describe('rates test', () => {
         expect(received).toEqual(expected);
     });
 
-    it('getPathAndRate from eos token to eos token (smart -> reserve)', async () => {
+    it('getPathAndRates from eos token to eos token (smart -> reserve)', async () => {
         const blockchainEOS = sdk._core.blockchains[BlockchainType.EOS] as eos.EOS;
         jest.spyOn(sdk._core.blockchains[BlockchainType.EOS], 'getAnchorToken')
             .mockImplementationOnce(() => ({ blockchainType: BlockchainType.EOS, blockchainId: 'aaaaaaaaaaaa', symbol: 'AAA' }));
@@ -350,7 +387,7 @@ describe('rates test', () => {
 
         await sdk.refresh();
 
-        const received = await sdk.pricing.getPathAndRate(
+        const received = await sdk.pricing.getPathAndRates(
             { blockchainType: BlockchainType.EOS, blockchainId: 'aaabbbaaabbb', symbol: 'AAABBB' },
             { blockchainType: BlockchainType.EOS, blockchainId: 'cccccccccccc', symbol: 'CCC' }
         );
@@ -366,10 +403,10 @@ describe('rates test', () => {
             rate: '1.8208'
         };
 
-        expect(received).toEqual(expected);
+        expect(received[0]).toEqual(expected);
     });
 
-    it('getPathAndRate from eos token to eos token (reserve -> smart)', async () => {
+    it('getPathAndRates from eos token to eos token (reserve -> smart)', async () => {
         const blockchainEOS = sdk._core.blockchains[BlockchainType.EOS] as eos.EOS;
         jest.spyOn(sdk._core.blockchains[BlockchainType.EOS], 'getAnchorToken')
             .mockImplementationOnce(() => ({ blockchainType: BlockchainType.EOS, blockchainId: 'aaaaaaaaaaaa', symbol: 'AAA' }));
@@ -380,7 +417,7 @@ describe('rates test', () => {
 
         await sdk.refresh();
 
-        const received = await sdk.pricing.getPathAndRate(
+        const received = await sdk.pricing.getPathAndRates(
             { blockchainType: BlockchainType.EOS, blockchainId: 'bbbbbbbbbbbb', symbol: 'BBB' },
             { blockchainType: BlockchainType.EOS, blockchainId: 'aaacccaaaccc', symbol: 'AAACCC' }
         );
@@ -396,13 +433,13 @@ describe('rates test', () => {
             rate: '12.5927'
         };
 
-        expect(received).toEqual(expected);
+        expect(received[0]).toEqual(expected);
     });
 
     it('getRateByPath from ethereum token to ethereum token', async () => {
         const spyGetRates = jest
             .spyOn(ethereum, 'getRates')
-            .mockImplementationOnce(() => Promise.resolve(['11111111111111111111']));
+            .mockImplementationOnce(() => Promise.resolve([['11111111111111111111']]));
 
         const spyGetDecimals = jest
             .spyOn(ethereum, 'getDecimals')
@@ -425,7 +462,7 @@ describe('rates test', () => {
     it('getRateByPath from ethereum token to eos token', async () => {
         const spyGetRates = jest
             .spyOn(ethereum, 'getRates')
-            .mockImplementationOnce(() => Promise.resolve(['1000000000000000000']));
+            .mockImplementationOnce(() => Promise.resolve([['1000000000000000000']]));
 
         const spyGetDecimals = jest
             .spyOn(ethereum, 'getDecimals')
@@ -460,7 +497,7 @@ describe('rates test', () => {
 
         const spyGetRates = jest
             .spyOn(ethereum, 'getRates')
-            .mockImplementationOnce(() => Promise.resolve(['11111111111111111111']));
+            .mockImplementationOnce(() => Promise.resolve([['11111111111111111111']]));
 
         const spyGetDecimals = jest
             .spyOn(ethereum, 'getDecimals')


### PR DESCRIPTION
Support contract multicall for multiple input amounts at once. 

For context, this is necessary for integrating Bancor liquidity into 0x API. When calculating a quote, we request rates for multiple input amounts to find the best rates to compose the total target amount of the quote. Discussed details with @yudilevi off-thread.

This PR modifies the `getRates` functions to support requesting rates for multiple input amounts in the same contract multicall. The output is is the rates per path, grouped by amount. E.g.:

```
getRates([ path1, path2 ], [ amount1, amount2 ]) = [
    [ rateForPath1Amount2, rateForPath2Amount1, rateForPath3Amount1],
    [ rateForPath1Amount2, rateForPath2Amount2, rateForPath3Amount3]
]
```

Interface changes:
* I added a function `getPathAndRates` to the Pricing module
* In `Core` module, `getPathAndRate` is now renamed to `getPathAndRates`. The function signature has changed too. However this is a private module so hopefully not a breaking change
* In `Blockchain` interface, `getRates(Token[][], string): Promise<string[]>` is now `getRates(Token[][], string[]): Promise<string[][]>`